### PR TITLE
增加了markdown中选择按哪一级标题分割卡片的新功能

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -15,8 +15,8 @@ SPECIAL_FIELDS = ['Tags']
 
 def doImport():
     # Raise the main dialog for the add-on and retrieve its result when closed.
-    level = 2
-    (file, did, model, fieldList, ok) = ImportSettingsDialog().getDialogResult()
+    #level = 2
+    (file, did, model, fieldList, level,ok) = ImportSettingsDialog().getDialogResult()
     if not ok: return
     if os.path.splitext(file)[-1] == '.html':
         # ACTIONS += ['标签']
@@ -158,15 +158,18 @@ class ImportSettingsDialog(QDialog):
         - 卡组
         - 笔记类型
         - 导入信息与笔记类型各领域的对应关系
+        - 分割层级
         - 是否导入
         """
 
-        if self.result() == QDialog.Rejected: return None, None, None, None, False
+        if self.result() == QDialog.Rejected: return None, None, None, None,None, False
 
         model = self.form.modelList.currentItem().model
         # Iterate the grid rows to populate the field map
         fieldList = []
         did = self.deck.selectedId()
+        level = self.form.level.currentText()
+        level = int(level)
         grid = self.form.fieldMapGrid
         for row in range(self.fieldCount):
             # QLabel with field name
@@ -176,7 +179,7 @@ class ImportSettingsDialog(QDialog):
             # QComboBox with index from the action list
             actionIdx = grid.itemAtPosition(row, 1).widget().currentIndex()
             fieldList.append((field, actionIdx, special))
-        return self.mediaDir, did, model, fieldList, True
+        return self.mediaDir, did, model, fieldList,level, True
 
     def onBrowse(self):
         """

--- a/dialog.py
+++ b/dialog.py
@@ -60,6 +60,20 @@ class Ui_Form(object):
         self.gridLayout.addWidget(self.buttonBox, 5, 3, 1, 1)
         self.verticalLayout.addLayout(self.gridLayout)
 
+        self.label_5 = QtWidgets.QLabel(Form)
+        self.label_5.setObjectName("label_5")
+        self.horizontalLayout_2.addWidget(self.label_5)
+        self.gridLayout.addWidget(self.label_5, 4, 0, 1, 1)
+        self.level = QtWidgets.QComboBox(Form)
+        self.level.addItem('2')
+        self.level.addItem('3')
+        self.level.addItem('4')
+        self.level.addItem('5')
+        self.level.addItem('6')
+        self.level.setCurrentIndex(0)
+        self.horizontalLayout_2.addWidget(self.level)
+        self.gridLayout.addWidget(self.level, 4, 3, 1, 1)
+        
         self.retranslateUi(Form)
         QtCore.QMetaObject.connectSlotsByName(Form)
 
@@ -71,3 +85,4 @@ class Ui_Form(object):
         self.label_4.setText(_translate("Form", "卡组："))
         self.label.setText(_translate("Form", "选择笔记类型"))
         self.label_2.setText(_translate("Form", "对应字段"))
+        self.label_5.setText(_translate("Form", "输入层级"))


### PR DESCRIPTION
在界面下方增加了可选层级的功能，可选的标题级别是2-6，默认是2.

未来还希望能增加将某种标记（e.g.下划线）转换成cloze（{{c1:: }}）的功能。但对正则表达式不太熟，而且不知道会不会对现有功能产生影响。

//第一次pull request好紧张QAQ